### PR TITLE
Fit Track: Docker Image Naming

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -54,13 +54,13 @@ jobs:
       - name: Build with Gradle
         run: gradle build
       - name: Build the Docker image
-        run: docker build . --file Dockerfile --tag ${{secrets.DOCKER_HUB_USERNAME}}/robinsonir-api:${{steps.build-number.outputs.BUILD_NUMBER}}
+        run: docker build . --file Dockerfile --tag ${{secrets.DOCKER_HUB_USERNAME}}/fit-track:${{steps.build-number.outputs.BUILD_NUMBER}}
       - name: Publish docker image to docker hub
-        run: docker push ${{secrets.DOCKER_HUB_USERNAME}}/robinsonir-api:${{steps.build-number.outputs.BUILD_NUMBER}}
+        run: docker push ${{secrets.DOCKER_HUB_USERNAME}}/fit-track:${{steps.build-number.outputs.BUILD_NUMBER}}
       - name: Build Docker image with latest tag
-        run: docker build . --file Dockerfile --tag ${{secrets.DOCKER_HUB_USERNAME}}/robinsonir-api:latest
+        run: docker build . --file Dockerfile --tag ${{secrets.DOCKER_HUB_USERNAME}}/fit-track:latest
       - name: Publish docker image to docker hub
-        run: docker push ${{secrets.DOCKER_HUB_USERNAME}}/robinsonir-api:latest
+        run: docker push ${{secrets.DOCKER_HUB_USERNAME}}/fit-track:latest
       - name: Deploy to Elastic Beanstalk
         uses: einaregilsson/beanstalk-deploy@v21
         with:

--- a/.github/workflows/frontend-cd.yml
+++ b/.github/workflows/frontend-cd.yml
@@ -40,20 +40,20 @@ jobs:
         run: |
           docker build . \
           --file Dockerfile \
-          --tag ${{secrets.DOCKER_HUB_USERNAME}}/robinsonir-react:${{steps.build-number.outputs.BUILD_NUMBER}} \
+          --tag ${{secrets.DOCKER_HUB_USERNAME}}/fit-track-ui:${{steps.build-number.outputs.BUILD_NUMBER}} \
           --build-arg api_base_url=http://fit-track-dev.eba-jpnjhwum.us-east-1.elasticbeanstalk.com:8080
         working-directory: fit-track-ui/react
       - name: Publish docker image to docker hub
-        run: docker push ${{secrets.DOCKER_HUB_USERNAME}}/robinsonir-react:${{steps.build-number.outputs.BUILD_NUMBER}}
+        run: docker push ${{secrets.DOCKER_HUB_USERNAME}}/fit-track-ui:${{steps.build-number.outputs.BUILD_NUMBER}}
       - name: Build Docker image with latest tag
         run: |
           docker build . \
           --file Dockerfile \
-          --tag ${{secrets.DOCKER_HUB_USERNAME}}/robinsonir-react:latest \
+          --tag ${{secrets.DOCKER_HUB_USERNAME}}/fit-track-ui:latest \
           --build-arg api_base_url=http://fit-track-dev.eba-jpnjhwum.us-east-1.elasticbeanstalk.com:8080
         working-directory: fit-track-ui/react
       - name: Publish docker image to docker hub
-        run: docker push ${{secrets.DOCKER_HUB_USERNAME}}/robinsonir-react:latest
+        run: docker push ${{secrets.DOCKER_HUB_USERNAME}}/fit-track-ui:latest
       - name: Wait 80 for Elastic Beanstalk status
         if: env.skip_wait == 'false'
         run: |

--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -2,8 +2,8 @@
   "AWSEBDockerrunVersion": 2,
   "containerDefinitions": [
     {
-      "name": "robinsonir-react",
-      "image": "robinsonir/robinsonir-react:latest",
+      "name": "fit-track-ui",
+      "image": "robinsonir/fit-track-ui:latest",
       "essential": true,
       "memory": 1024,
       "portMappings": [
@@ -14,8 +14,8 @@
       ]
     },
     {
-      "name": "robinsonir-api",
-      "image": "robinsonir/robinsonir-api:latest",
+      "name": "fit-track",
+      "image": "robinsonir/fit-track:latest",
       "essential": true,
       "memory": 512,
       "portMappings": [

--- a/fit-track-ui/react/vite.config.ts
+++ b/fit-track-ui/react/vite.config.ts
@@ -8,10 +8,7 @@ export default defineConfig({
     server: {
         host: "0.0.0.0",
         port: 5173,
-        allowedHosts: [
-            "fitness-tracker-env.eba-3f5efq3k.us-east-1.elasticbeanstalk.com",
-            "fit-track-dev.eba-jpnjhwum.us-east-1.elasticbeanstalk.com"
-        ],
+        allowedHosts: ["fit-track-dev.eba-jpnjhwum.us-east-1.elasticbeanstalk.com"],
     },
     esbuild: {
         target: "es2020",

--- a/fit-track/Dockerfile
+++ b/fit-track/Dockerfile
@@ -2,7 +2,7 @@
 FROM openjdk:17-jdk-alpine
 
 # Copy the backend (Java application) JAR file into the image
-COPY /build/libs/fit-track-*.jar fitness-tracker-api.jar
+COPY /build/libs/fit-track-*.jar fit-track.jar
 
 # Define the command to run the Java backend
-CMD ["java", "-jar", "fitness-tracker-api.jar"]
+CMD ["java", "-jar", "fit-track.jar"]


### PR DESCRIPTION
<!-- Thank you for using the Fit Track pull request template. -->

# Fit Track: Docker Image Naming

## Description

Standardize Docker image naming conventions and optimize build configurations for the fitness tracker application's containerized deployment pipeline.

## Changes

- **ackend API**: Renamed Docker images from `robinsonir-api` to `fit-track` for consistency
- **Frontend UI**: Renamed Docker images from `robinsonir-react` to `fit-track-ui` for clarity
- **Container naming**: Updated container names in `Dockerrun.aws.json` to match new image naming scheme
- **JAR file naming**: Aligned backend JAR naming from `fitness-tracker-api.jar` to `fit-track.jar`

### 🔄 **CI/CD Pipeline Updates**
- **Backend workflow**: Updated to build and push `fit-track` images instead of `robinsonir-api` `backend-cd.yml`
- **Frontend workflow**: Updated `frontend-cd.yml` to build and push `fit-track-ui` images instead of `robinsonir-react`
- **Version tagging**: Maintained both build-number and `latest` tag strategies with new naming
- **Docker Hub integration**: Updated all Docker Hub push commands to use new image names


## Testing

- *Describe what was the old behavior and what is the new behavior.*

## Additional Comments

- *(Optional) Anything else that you may want to add.*

# Checklist

- [x] All tests are passing
- [x] Documentation updated (if needed)
- [x] No TODOs left
- [x] Code is formatted properly
